### PR TITLE
chore: add wool0826 to CLA contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -110,7 +110,8 @@
     "kzmshx",
     "safijunaid17",
     "roulettedares",
-    "ouchi2501"
+    "ouchi2501",
+    "wool0826"
   ],
   "message": "We require contributors to sign our Contributor License Agreement, and we don't have yours on file. In order for us to review and merge your code, please sign [CLA](https://forms.gle/zcNM9TL1iVU1fQ1G9) and add your name to [contributors list](https://github.com/bytebase/clabot-config/blob/main/.clabot).",
   "label": "cla-signed",


### PR DESCRIPTION
Signed the CLA and adding my GitHub username to the contributors list, per the `.clabot` instructions. This is for https://github.com/bytebase/bytebase/pull/20660.